### PR TITLE
fix(sway): the semicolon in the trait-item is missing

### DIFF
--- a/src/sway/diagrams/trait-item.txt
+++ b/src/sway/diagrams/trait-item.txt
@@ -1,5 +1,5 @@
 <
-    'const',
-    'fn-signature',
-    'trait-type'
+    ['const' ";"?],
+    ['fn-signature' ";"?],
+    ['trait-type' ";"?]
 >


### PR DESCRIPTION
fix(sway): the semicolon in the trait-item is missing